### PR TITLE
Bump ghc dependency to 8.10

### DIFF
--- a/Formula/githud.rb
+++ b/Formula/githud.rb
@@ -12,7 +12,7 @@ class Githud < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc@8.8" => :build
+  depends_on "ghc@8.10" => :build
 
   def install
     system "cabal", "v2-update"


### PR DESCRIPTION
GHC only maintain computer with arm64, e.g. M1 cpu, to install version above 8.10, which can run Githud without any issue.